### PR TITLE
check current version number instead of hardcoded 6.0.0.1 + simplify …

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,13 @@ pub fn initialize(multithread: bool) -> Result<(), PapiError> {
     Ok(())
 }
 
+/// ALL EventsSet should be dropped before calling this
+pub fn terminate() {
+    unsafe {
+        PAPI_shutdown();
+    }
+}
+
 pub fn is_initialized() -> bool {
     unsafe { check_error(PAPI_is_initialized()).is_ok() }
 }
@@ -108,6 +115,7 @@ mod tests {
     use crate::counter::Counter;
     use crate::events_set::EventsSet;
     use crate::initialize;
+    use crate::terminate;
     use crate::PapiError;
 
     #[test]
@@ -143,6 +151,9 @@ mod tests {
                 fv, x, counters[0], counters[1]
             );
         }
+        drop(counters);
+        drop(event_set);
+        terminate()
     }
 
     fn fib(n: isize) -> isize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,38 +129,6 @@ mod tests {
             msg,
             "PapiError with error code -7, i.e \"Event does not exist\""
         );
-    }
-
-    #[test]
-    fn test_fib() {
-        initialize(true).unwrap();
-
-        let counters = vec![
-            Counter::from_name("ix86arch::INSTRUCTION_RETIRED").unwrap(),
-            Counter::from_name("ix86arch::MISPREDICTED_BRANCH_RETIRED").unwrap(),
-        ];
-
-        let mut event_set = EventsSet::new(&counters).unwrap();
-
-        for fv in 1..15 {
-            event_set.start().unwrap();
-            let x = fib(fv);
-            let counters = event_set.stop().unwrap();
-            println!(
-                "Computed fib({}) = {} in {} instructions [mispredicted: {}].",
-                fv, x, counters[0], counters[1]
-            );
-        }
-        drop(counters);
-        drop(event_set);
         terminate()
-    }
-
-    fn fib(n: isize) -> isize {
-        if n < 2 {
-            1
-        } else {
-            fib(n - 1) + fib(n - 2)
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,11 +32,8 @@ pub struct PapiError {
 
 impl Debug for PapiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        print!("Hi");
         let err_msg_buf = unsafe { PAPI_strerror(self.code) };
-        print!("Hi ok");
         let err_msg = unsafe { CStr::from_ptr(err_msg_buf) };
-        print!("Hi ok2");
         write!(
             f,
             "PapiError with error code {}, i.e \"{}\"",

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,36 @@
+use papi_bindings::counter::Counter;
+use papi_bindings::events_set::EventsSet;
+use papi_bindings::{initialize, terminate};
+
+#[test]
+fn test_fib() {
+    initialize(true).unwrap();
+
+    let counters = vec![
+        Counter::from_name("ix86arch::INSTRUCTION_RETIRED").unwrap(),
+        Counter::from_name("ix86arch::MISPREDICTED_BRANCH_RETIRED").unwrap(),
+    ];
+
+    let mut event_set = EventsSet::new(&counters).unwrap();
+
+    for fv in 1..15 {
+        event_set.start().unwrap();
+        let x = fib(fv);
+        let counters = event_set.stop().unwrap();
+        println!(
+            "Computed fib({}) = {} in {} instructions [mispredicted: {}].",
+            fv, x, counters[0], counters[1]
+        );
+    }
+    drop(counters);
+    drop(event_set);
+    terminate()
+}
+
+fn fib(n: isize) -> isize {
+    if n < 2 {
+        1
+    } else {
+        fib(n - 1) + fib(n - 2)
+    }
+}


### PR DESCRIPTION
…test

I just tried  the lib with the latest papi version 7.0.0.0, but it crashed with error -1 (invalid argument) when "papibindings::initialize" is called. This is happening because the version number is hardcoded to 6.0.0.1, so I changed it by reading the output of papi_version which is kind of ugly, but it worked. 

Also, I changed the test because of a crash occurring with error code -10 "Event Set is currently running" since 2 sets are running simultaneously. And reduce the loop length because it was long. 